### PR TITLE
feature/no-padding

### DIFF
--- a/cmd/shecomp/main.go
+++ b/cmd/shecomp/main.go
@@ -50,9 +50,14 @@ func run(c *cli.Context) error {
 	}
 
 	// switch the output mode
+	if c.Bool("padding") && c.Bool("nopad") {
+		return errors.New("both the padding and nopad flags are specified")
+	}
 	var fn func(r io.Reader) ([]byte, error)
 	if c.Bool("padding") {
 		fn = shecomp.Padding
+	} else if c.Bool("nopad") {
+		fn = shecomp.CompressWithoutPadding
 	} else {
 		fn = shecomp.Compress
 	}
@@ -83,6 +88,10 @@ func main() {
 				Name:    "padding",
 				Aliases: []string{"p"},
 				Usage:   "switch output mode to return only padding",
+			},
+			&cli.BoolFlag{
+				Name:  "nopad",
+				Usage: "compress the input data without padding",
 			},
 		},
 		Action: run,

--- a/shecomp_test.go
+++ b/shecomp_test.go
@@ -93,3 +93,40 @@ func TestCompress(t *testing.T) {
 		})
 	}
 }
+
+func TestCompressWithoutPadding(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"example described in SHE specification 4.13.2.10",
+			"000102030405060708090a0b0c0d0e0f010153484500800000000000000000b0",
+			[]byte("118a46447a770d87828a69c222e2d17e"),
+			false,
+		},
+		{
+			"the input is not multiple of block size",
+			"0000000000000000000000000000000",
+			nil,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := shecomp.CompressWithoutPadding(strings.NewReader(tt.input))
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("Compress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2 

- Add CompressWithoutPadding func into the root package
- Add `--nopad` flag into the `cmd/shecomp`