### PR TITLE
test: confirm ErrLargePlainText

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -1,0 +1,27 @@
+package shecomp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestErrLargePlainText(t *testing.T) {
+	// Test ErrLargePlainText.
+	// To shorten the test time, override a private field: paddingReader. maxBitLength.
+
+	// To check the boundary of the error, read twice.
+	// The first time, check that no error occurs, and the second time, check that an error occurs.
+	s := strings.Repeat("00", 2*blockSize)
+	br := newPaddingReader(strings.NewReader(s))
+	br.readBytes = maxBitLength/8 - blockSize
+
+	o := make([]byte, blockSize)
+
+	if err := br.block(o); err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+	if err := br.block(o); !errors.Is(err, ErrLargePlainText) {
+		t.Errorf("Expected ErrLargePlainText, got %v", err)
+	}
+}


### PR DESCRIPTION
closes #5 

I initially intended to add a test for the `Compress` function to verify that it returns ErrLargePlainText when a large input is passed. However, the tests were taking too long to run, so I decided to write a test for the private structure with overwriting its field to reduce test time.